### PR TITLE
[CO]: Tweak caching for public keys

### DIFF
--- a/lib/jwt-authentication/cache/keyCache.js
+++ b/lib/jwt-authentication/cache/keyCache.js
@@ -1,7 +1,7 @@
 var NodeCache = require('node-cache');
 
 var cacheOptions = {
-    stdTTL: 10 * 60, // 10 minutes
+    stdTTL: 24 * 60 * 60, // 24 hours
     checkperiod: 10 // 10 seconds
 };
 

--- a/lib/jwt-authentication/request.js
+++ b/lib/jwt-authentication/request.js
@@ -9,7 +9,7 @@ var makeRequest = function(url) {
         headers: {
             'Accept': 'application/x-pem-file'
         },
-        timeout: 15 * 1000 // 15 seconds
+        timeout: 10 * 1000 // 15 seconds
     };
 
     return q(axios.get(url, options))

--- a/lib/jwt-authentication/request.js
+++ b/lib/jwt-authentication/request.js
@@ -9,7 +9,7 @@ var makeRequest = function(url) {
         headers: {
             'Accept': 'application/x-pem-file'
         },
-        timeout: 10 * 1000 // 15 seconds
+        timeout: 10 * 1000 // 10 seconds
     };
 
     return q(axios.get(url, options))


### PR DESCRIPTION
Currently public keys are cached in our node services that implement ASAP for 10 minutes at a time. As we do not rotate keys currently, this means we are making a large number of unnecessary requests to S3.

S3 has been seeing spikes of high latency in responding to requests, so we should reduce the number of requests to reduce impact on customers.

This PR also reduces the key fetch timeout from 15s -> 10s to save time when the request is going to timeout.