### PR TITLE
Update lodash 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/jwt-authentication/json-web-token.js
+++ b/lib/jwt-authentication/json-web-token.js
@@ -31,8 +31,6 @@ module.exports = {
             iat: options.iat
         });
 
-        console.log(jsonWebTokenClaims);
-
         var jsonWebTokenOptions = {
             algorithm: 'RS256',
             expiresIn: options.expiresInSeconds || 30,

--- a/lib/jwt-authentication/json-web-token.js
+++ b/lib/jwt-authentication/json-web-token.js
@@ -31,6 +31,8 @@ module.exports = {
             iat: options.iat
         });
 
+        console.log(jsonWebTokenClaims);
+
         var jsonWebTokenOptions = {
             algorithm: 'RS256',
             expiresIn: options.expiresInSeconds || 30,

--- a/lib/server/validator/jwt-claims-validator.js
+++ b/lib/server/validator/jwt-claims-validator.js
@@ -20,7 +20,7 @@ var validateIssuerIsNotEmpty = function(issuer) {
 };
 
 var subjectValidation = function(authorizedSubjects, subject) {
-    if (authorizedSubjects && !_.contains(authorizedSubjects, subject)) {
+    if (authorizedSubjects && !_.includes(authorizedSubjects, subject)) {
         return q.reject(new Error('Unknown or unauthorized subject'));
     }
     return q.resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^0.15.3",
         "ducktype": "^1.1.0",
         "jsonwebtoken": "^5.0.0",
-        "lodash": "^3.0.0",
+        "lodash": "^4.17.21",
         "node-cache": "^3.0.0",
         "node-forge": "^0.6.48",
         "q": "^1.5.0"
@@ -594,12 +594,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/catharsis/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -1019,6 +1013,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/conventional-changelog/node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.1.3",
@@ -2792,12 +2792,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/grunt-jasmine-nodejs/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/grunt-jasmine-nodejs/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3522,6 +3516,12 @@
         "q": "^1.4.1"
       }
     },
+    "node_modules/jasmine-http-server-spy/node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+      "dev": true
+    },
     "node_modules/jasmine-reporters": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.5.0.tgz",
@@ -3705,12 +3705,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/jsdoc-parse/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/jsdoc-parse/node_modules/marked": {
       "version": "0.3.19",
@@ -3997,9 +3991,9 @@
       "dev": true
     },
     "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/longest": {
       "version": "1.0.1",
@@ -4433,11 +4427,6 @@
       "engines": {
         "node": ">= 0.4.6"
       }
-    },
-    "node_modules/node-cache/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/node-forge": {
       "version": "0.6.49",
@@ -5178,12 +5167,6 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
-    },
-    "node_modules/requizzle/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -6672,14 +6655,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        }
       }
     },
     "center-align": {
@@ -7040,6 +7015,12 @@
             "get-stdin": "^4.0.1",
             "meow": "^3.3.0"
           }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+          "dev": true
         }
       }
     },
@@ -8464,12 +8445,6 @@
             "esprima": "^4.0.0"
           }
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        },
         "minimatch": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9068,6 +9043,14 @@
         "express": "^4.13.1",
         "lodash": "^3.10.0",
         "q": "^1.4.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
+          "dev": true
+        }
       }
     },
     "jasmine-reporters": {
@@ -9194,12 +9177,6 @@
             "underscore": "~1.6.0",
             "wrench": "~1.3.9"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
         },
         "marked": {
           "version": "0.3.19",
@@ -9426,9 +9403,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "longest": {
       "version": "1.0.1",
@@ -9777,13 +9754,6 @@
       "requires": {
         "clone": "1.0.x",
         "lodash": "4.x"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
       }
     },
     "node-forge": {
@@ -10388,14 +10358,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        }
       }
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "axios": "^0.15.3",
     "ducktype": "^1.1.0",
     "jsonwebtoken": "^5.0.0",
-    "lodash": "^3.0.0",
+    "lodash": "^4.17.21",
     "node-cache": "^3.0.0",
     "node-forge": "^0.6.48",
     "q": "^1.5.0"

--- a/test/unit/jwt-authentication/json-web-token.spec.js
+++ b/test/unit/jwt-authentication/json-web-token.spec.js
@@ -30,7 +30,7 @@ describe('jwt-authentication/json-web-token', function () {
         it('should pass through the arguments to jsonWebToken.sign', function() {
             jwtPromiseWrapper.create({iss: 'issuer', sub: 'subject'}, {kid: 'a-kid', privateKey: 'private-key'});
             expect(jsonWebToken.sign).toHaveBeenCalledWith(
-                {iss: 'issuer', sub: 'subject', jti: jasmine.any(String)},
+                {iss: 'issuer', sub: 'subject', jti: jasmine.any(String), nbf: undefined, iat: undefined},
                 'private-key',
                 {algorithm: 'RS256', expiresIn: 30, headers: {kid: 'a-kid'}});
         });
@@ -52,8 +52,14 @@ describe('jwt-authentication/json-web-token', function () {
                 {privateKey: 'private-key'}
             );
             expect(jsonWebToken.sign).toHaveBeenCalledWith(
-                {iss: 'issuer', sub: 'subject', jti: jasmine.any(String),
-                    claim1: 'foo', claim2: 'bar'
+                {
+                  iss: 'issuer',
+                  sub: 'subject',
+                  jti: jasmine.any(String),
+                  claim1: 'foo',
+                  claim2: 'bar',
+                  nbf: undefined,
+                  iat: undefined
                 },
                 jasmine.any(String),
                 jasmine.any(Object));


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

This PR updates `lodash` to `^4.17.21` which patches a prototype pollution vuln.

## Problem description

In an attempt to address security issues in `alexandria`, we discovered that, transitively, we have an old version of `lodash`.
<details>
  <summary>Alexandria lodash dep graph</summary>

```
├─┬ @safetyculture/autoshare@4.2.0
│ └── lodash@4.17.21 deduped
├─┬ @safetyculture/event-queue-client@9.1.4
│ └── lodash@4.17.21 deduped
├─┬ @safetyculture/hapi-bunyan@3.4.1
│ └── lodash@4.17.21 deduped
├─┬ @safetyculture/soter-jwt@3.3.4
│ ├─┬ @safetyculture/jwt-authentication@0.4.11
│ │ ├── lodash@3.10.1 <=================== HERE IS THE PROBLEM
│ │ └─┬ node-cache@3.2.1
│ │   └── lodash@4.17.21 deduped
│ └─┬ request-promise@4.2.6
│   └─┬ request-promise-core@1.1.4
│     └── lodash@4.17.21 deduped
├─┬ dependency-check@2.10.1
│ └─┬ async@2.6.4
│   └── lodash@4.17.21 deduped
├─┬ elasticsearch@15.5.0
│ └── lodash@4.17.21 deduped
├─┬ istanbul@1.0.0-alpha.2
│ └─┬ istanbul-api@1.3.7
│   ├─┬ async@2.6.4
│   │ └── lodash@4.17.21 deduped
│   └─┬ istanbul-lib-instrument@1.10.2
│     ├─┬ babel-generator@6.26.1
│     │ └── lodash@4.17.21 deduped
│     ├─┬ babel-template@6.26.0
│     │ └── lodash@4.17.21 deduped
│     ├─┬ babel-traverse@6.26.0
│     │ └── lodash@4.17.21 deduped
│     └─┬ babel-types@6.26.0
│       └── lodash@4.17.21 deduped
├─┬ launchdarkly-node-server-sdk@5.14.6
│ └─┬ node-cache@4.2.1
│   └── lodash@4.17.21 deduped
├── lodash@4.17.21
├─┬ nock@9.6.1
│ └── lodash@4.17.21 deduped
├─┬ nsp@3.2.1
│ ├─┬ cli-table2@0.2.0
│ │ └── lodash@3.10.1
│ └─┬ inquirer@3.3.0
│   └── lodash@4.17.21 deduped
├─┬ prettier-eslint-cli@5.0.1
│ ├─┬ eslint@5.16.0
│ │ ├─┬ inquirer@6.5.2
│ │ │ └── lodash@4.17.21 deduped
│ │ ├── lodash@4.17.21 deduped
│ │ └─┬ table@5.4.6
│ │   └── lodash@4.17.21 deduped
│ └─┬ prettier-eslint@9.0.2
│   └─┬ vue-eslint-parser@2.0.3
│     └── lodash@4.17.21 deduped
├─┬ prettier-eslint@12.0.0
│ ├─┬ @typescript-eslint/parser@3.10.1
│ │ └─┬ @typescript-eslint/typescript-estree@3.10.1
│ │   └── lodash@4.17.21 deduped
│ └─┬ vue-eslint-parser@7.1.1
│   └── lodash@4.17.21 deduped
├─┬ request-promise@2.0.1
│ └── lodash@4.17.21 deduped
└─┬ sinon@4.5.0
  └─┬ nise@1.5.3
    └─┬ @sinonjs/formatio@3.2.2
      └─┬ @sinonjs/samsam@3.3.3
        └── lodash@4.17.21 deduped
```
</details>

Patching this repo should also patch that version.

## Pros/cons of approach implemented
A couple of breaking changes in `lodash` forced some changes:
1. `_.contains` has become `_.includes`
2. `_.merge` now assigns `undefined` to keys that aren't present in the merge destination, as in the [changelog](https://github.com/lodash/lodash/wiki/Changelog#v400).

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
